### PR TITLE
module-compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "gamecontroller.js",
   "version": "1.5.0",
   "description": "A JavaScript library that lets you handle, configure, and use gamepad and controllers on a browser, using the Gamepad API",
-  "main": "dist/gamecontroller.min.js",
+  "type": "module",
+  "main": "src/index.js",
   "scripts": {
     "build": "webpack --output-filename gamecontroller.min.js --mode production",
     "build:dev": "webpack --output-filename gamecontroller.js --mode development",

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,5 @@ if (isGamepadSupported()) {
 } else {
   error(MESSAGES.NO_SUPPORT);
 }
+
+export default gameControl;


### PR DESCRIPTION
Hello

I know you are not maintaining this package anymore,

But at least can you accept this change?  
Your package is written using ES Module in the source, the new specs want developers to update their `package.json` to explicitly specify this (using `"type": "module"`). This helps the node module resolver to find the right file to import inside a project that depends on your package. It also helps bundlers and other analyzer tools to properly include the file in the process.

I also changed the property `main` because it pointed to the compiled version of your package which is incorrect. it has to point to the index file of your source in most case because that's what the node module resolver is looking for in an interconnected modules ecosystem.

Without that people wanting to use your package inside their building process have to write:

```typescript
import gamepad from 'gamecontroller.js/src/index.js';
```

This change will allow them to write:

```typescript
import gamepad from 'gamecontroller.js';
```
